### PR TITLE
Fix broken queries for metadata & address NPM Vulnerabilities

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,16 +51,17 @@ class CosmicJsSource {
           date: item.created_at,
           content: item.content,
           path: `${objectType}/${item.slug}`,
-          nextPath:
-            index < items.length - 1
-              ? `${objectType}/${items[index + 1].slug}`
-              : null,
-          prevPath:
-            index > 0 ? `${objectType}/${items[index - 1].slug}` : null,
-          nextTitle:
-            index < items.length - 1 ? `${items[index + 1].title}` : null,
-          prevTitle: index > 0 ? `${items[index - 1].title}` : null,
-          ...item,
+          metadata: {
+            nextPath:
+              index < items.length - 1
+                ? `${objectType}/${items[index + 1].slug}`
+                : null,
+            prevPath: index > 0 ? `${objectType}/${items[index - 1].slug}` : null,
+            nextTitle:
+              index < items.length - 1 ? `${items[index + 1].title}` : null,
+            prevTitle: index > 0 ? `${items[index - 1].title}` : null,
+            ...item,
+          }
         }
         contentType.addNode(node)
       })

--- a/index.js
+++ b/index.js
@@ -50,18 +50,19 @@ class CosmicJsSource {
           slug: item.slug || '',
           date: item.created_at,
           content: item.content,
-          path: `${objectType}/${item.slug}`,
+          path: `/${objectType}/${item.slug}`,
+          nextPath:
+            index < items.length - 1
+              ? `/${objectType}/${items[index + 1].slug}`
+              : null,
+          prevPath:
+            index > 0 ? `/${objectType}/${items[index - 1].slug}` : null,
+          nextTitle:
+            index < items.length - 1 ? `${items[index + 1].title}` : null,
+          prevTitle: index > 0 ? `${items[index - 1].title}` : null,
           metadata: {
-            nextPath:
-              index < items.length - 1
-                ? `${objectType}/${items[index + 1].slug}`
-                : null,
-            prevPath: index > 0 ? `${objectType}/${items[index - 1].slug}` : null,
-            nextTitle:
-              index < items.length - 1 ? `${items[index + 1].title}` : null,
-            prevTitle: index > 0 ? `${items[index - 1].title}` : null,
-            ...item,
-          }
+            ...item.metadata,
+          },
         }
         contentType.addNode(node)
       })

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ class CosmicJsSource {
   }
 
   async fetchContent(store) {
-    const { addContentType } = store
+    const { addCollection } = store
     const {
       typeName,
       apiURL,
@@ -39,7 +39,7 @@ class CosmicJsSource {
     const data = await Promise.all(promises)
 
     objectTypes.forEach((objectType, i) => {
-      const contentType = addContentType({
+      const contentType = addCollection({
         typeName: `${typeName}${capitalize(objectType)}`,
       })
       var items = data[i]
@@ -51,18 +51,16 @@ class CosmicJsSource {
           date: item.created_at,
           content: item.content,
           path: `${objectType}/${item.slug}`,
-          fields: {
-            nextPath:
-              index < items.length - 1
-                ? `${objectType}/${items[index + 1].slug}`
-                : null,
-            prevPath:
-              index > 0 ? `${objectType}/${items[index - 1].slug}` : null,
-            nextTitle:
-              index < items.length - 1 ? `${items[index + 1].title}` : null,
-            prevTitle: index > 0 ? `${items[index - 1].title}` : null,
-            ...item,
-          },
+          nextPath:
+            index < items.length - 1
+              ? `${objectType}/${items[index + 1].slug}`
+              : null,
+          prevPath:
+            index > 0 ? `${objectType}/${items[index - 1].slug}` : null,
+          nextTitle:
+            index < items.length - 1 ? `${items[index + 1].title}` : null,
+          prevTitle: index > 0 ? `${items[index - 1].title}` : null,
+          ...item,
         }
         contentType.addNode(node)
       })

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,12 @@
   "requires": true,
   "dependencies": {
     "axios": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.17.1.tgz",
-      "integrity": "sha1-LY4+XQvb1zJ/kbyBT1xXZg+Bgk0=",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.0.tgz",
+      "integrity": "sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==",
       "requires": {
-        "follow-redirects": "^1.2.5",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
       }
     },
     "buffer-from": {
@@ -57,11 +57,11 @@
       }
     },
     "follow-redirects": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.0.tgz",
-      "integrity": "sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "requires": {
-        "debug": "^3.1.0"
+        "debug": "=3.1.0"
       }
     },
     "inherits": {
@@ -71,9 +71,9 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "isarray": {
       "version": "1.0.0",
@@ -88,9 +88,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lru-cache": {
       "version": "4.1.3",

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "cosmicjs"
   ],
   "dependencies": {
-    "axios": "^0.17.1",
-    "lodash": "^4.17.4"
+    "axios": "^0.19.0",
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "prettier": "^1.5.3",


### PR DESCRIPTION
👋 

I found an issue which was preventing usage of metadata in graphql queries with this plugin. It was a result of some deprecations coming out of the Gridsome v0.7 update.
* The addContentType() action was renamed renamed to addCollection().
* The fields property in addNode() is deprecated. Custom fields should be set in the root of the node

This fixes pretty bad issue with modules failing to load when you attempt to have queries pull metatdata from cosmic js objects.