### PR TITLE
Fix issue preventing `gridsome develop`

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ class CosmicJsSource {
         }
         const node = {
           id: item._id,
-          ...node,
+          ...item,
           ...custom_fields,
         }
         contentType.addNode(node)


### PR DESCRIPTION
This PR addresses a syntax issue introduced from a previous commit which is essentially breaks the plugin. 

Within the initialization of the `node` constant a spread operator on the `node` property exists. This throws an error because you cannot access the values of `node` before initialization. I'm fairly certain this was meant to be a spread over the `item` iterator anyways. 